### PR TITLE
Use docker-compose for all services in movies-api-java + agent.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ dd-java-agent.jar
 
 # Ignore log files
 *.log
+
+# Docker secrets
+docker.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM eclipse-temurin:17  
+
+COPY . /usr/src/movies-api-java
+WORKDIR /usr/src/movies-api-java
+#RUN wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
+
+RUN ./gradlew 
+
+RUN chmod +x ./run.sh
+ENTRYPOINT [ "./run.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,7 @@ FROM eclipse-temurin:17
 
 COPY . /usr/src/movies-api-java
 WORKDIR /usr/src/movies-api-java
-#RUN wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
-
-RUN ./gradlew 
+RUN wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
 
 RUN chmod +x ./run.sh
 ENTRYPOINT [ "./run.sh" ]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # dd-continuous-profiler-dash2023
 
 Example service used for the [_Diagnose and Optimize Code Performance with Continuous Profiler_](https://www.dashcon.io/workshops/diagnose-and-optimize-code-performance-with-continuous-profiler/) workshop.
+
+## How to Run
+
+Assuming you have docker installed and the daemon running, just execute the following command in your terminal:
+
+```bash
+$ docker-compose up
+```

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,16 @@ application {
     applicationDefaultJvmArgs = [
         "-Xmx3g",
         "-Xms3g",
+        "-javaagent:dd-java-agent.jar",
+        "-Ddd.profiling.enabled=true",
+        "-XX:FlightRecorderOptions=stackdepth=256",
+        "-Ddd.logs.injection=true",
+        "-Ddd.trace.sample.rate=1",
+        "-Ddd.service=movies-api-java",
+        "-Ddd.env=prod",
+        // Tag each run with a different version
+        "-Ddd.version=${LocalDateTime.now().withNano(0)}",
+        "-Ddd.profiling.ddprof.wall.enabled=true"
     ]
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,23 @@ services:
     - ./mongo-seed:/docker-entrypoint-initdb.d
     ports:
     - 127.0.0.1:27017:27017/tcp
+  movies-api-java:
+    image: movies-api-java
+    environment:
+      DD_AGENT_HOST: 'datadog-agent'
+    ports:
+    - 127.0.0.1:8081:8081/tcp 
+  datadog-agent:
+    image: datadog/agent:latest
+    env_file:
+      - docker.env
+    environment:
+      DD_SITE: 'datad0g.com'
+      DD_APM_ENABLED: 'true'
+      DD_APM_NON_LOCAL_TRAFFIC: 'true'
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /proc/:/host/proc/:ro
+      - /sys/fs/cgroup:/host/sys/fs/cgroup:ro
+    expose:
+      - "8126"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     env_file:
       - docker.env
     environment:
-      DD_SITE: 'datad0g.com'
+      DD_SITE: 'datadoghq.com'
       DD_APM_ENABLED: 'true'
       DD_APM_NON_LOCAL_TRAFFIC: 'true'
     volumes:

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./gradlew run

--- a/src/main/java/movies/Server.java
+++ b/src/main/java/movies/Server.java
@@ -46,7 +46,7 @@ public class Server {
 
 	public static void main(String[] args) {
 		port(8081);
-		ipAddress("127.0.0.1");
+		ipAddress("0.0.0.0");
 		get("/", Server::randomMovieEndpoint);
 		get("/credits", Server::creditsEndpoint);
 		get("/movies", Server::moviesEndpoint);
@@ -170,7 +170,7 @@ public class Server {
 
 	private static List<Credit> loadCredits() {
 		try (
-			var mongoClient = MongoClients.create()
+			var mongoClient = MongoClients.create("mongodb://movies-api-mongo:27017")
 		) {
 			var creditsCollection = mongoClient.getDatabase("moviesDB").getCollection("credits");
 			return StreamSupport.stream(creditsCollection.find().batchSize(5_000).map(Credit::new).spliterator(), false).toList();


### PR DESCRIPTION
Motivation: docker-compose is much better for developing the profiling lab since we can't generate things like timeline with the java profiler on macos. Also, it could provide a more consistent way to deploy movies-api-java/datadog-agent in the instruqt environment. We already use it for mongodb. Note: we wouldn't want the datadog-agent started through docker-compose in intro labs where we want the user to set up the agent themselves. 